### PR TITLE
fix: prevent crash when git is not avail

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ async function getLastCommit() {
     const result = {
       hash
     };
+    /* istanbul ignore if */
     if (gitTag) {
       result.tag = gitTag;
     }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,24 @@ const readPkgUp = require('read-pkg-up');
 const LastCommitLog = require('last-commit-log');
 
 /**
- * Information about the app
+ * A safe way to query for git infos.
+ *
+ * @return {object|undefined} Returns {hash, gitTag} or undefined in case of an error
+ */
+async function getLastCommit() {
+  try {
+    const lastCommitLog = new LastCommitLog();
+    const { hash, gitTag } = await lastCommitLog.getLastCommit();
+    return { hash, gitTag };
+  } catch (err) {}
+}
+
+/**
+ * Information about the app.
+ *
+ * The git infos can be missing if the project has no commit yet
+ * or is not connected to a git repo.
+ *
  * @typedef {Object} AppInfo
  * @property {string} name The name of the app
  * @property {string} version The version of the app
@@ -21,11 +38,9 @@ const LastCommitLog = require('last-commit-log');
  * @return {Promise<AppInfo>} A promise that resolves the app info
  */
 async function parseAppInfo() {
-  const lastCommitLog = new LastCommitLog();
-
   const [packageInfo, lastCommit] = await Promise.all([
     readPkgUp(),
-    lastCommitLog.getLastCommit()
+    getLastCommit()
   ]);
 
   const { NODE_ENV, HOSTNAME } = process.env;
@@ -34,8 +49,7 @@ async function parseAppInfo() {
     name: packageInfo.pkg.name,
     version: packageInfo.pkg.version,
     node: process.version,
-    hash: lastCommit.hash,
-    tag: lastCommit.gitTag,
+    ...lastCommit,
     environment: /* istanbul ignore next */ NODE_ENV || 'development',
     hostname: /* istanbul ignore next */ HOSTNAME || require('os').hostname(),
     pid: process.pid

--- a/index.js
+++ b/index.js
@@ -10,7 +10,14 @@ async function getLastCommit() {
   try {
     const lastCommitLog = new LastCommitLog();
     const { hash, gitTag } = await lastCommitLog.getLastCommit();
-    return { hash, gitTag };
+    // Add gitTag only when it exists
+    const result = {
+      hash
+    };
+    if (gitTag) {
+      result.tag = gitTag;
+    }
+    return result;
   } catch (err) {}
 }
 


### PR DESCRIPTION
The appInfo will then just not contain the `hash` and `tag` members.

Closes #2 