### PR TITLE
fix: conditionally support os version based on node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "debug": "^4.1.1",
     "last-commit-log": "^3.0.4",
     "lodash": "^4.17.15",
-    "read-pkg-up": "^7.0.1"
+    "read-pkg-up": "^7.0.1",
+    "semver": "^7.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const LastCommitLog = require('last-commit-log');
 const _ = require('lodash');
 const debug = require('debug')('parse-app-info');
 const readPkgUp = require('read-pkg-up');
+const semver = require('semver');
 
 const OS_METHODS = [
   'arch',
@@ -22,9 +23,14 @@ const OS_METHODS = [
   'totalmem',
   'type',
   'uptime',
-  'userInfo', // => user
-  'version'
+  'userInfo' // => user
 ];
+
+// `os.version` added in 13.11.0
+// https://nodejs.org/api/os.html#os_os_version
+if (semver.satisfies(process.version, 'v13.11.0')) {
+  OS_METHODS.push('version');
+}
 
 //
 // Information about the app.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7393,6 +7393,11 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 serialize-error@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"


### PR DESCRIPTION
[os.version()](https://nodejs.org/api/os.html#os_os_version) was added in 13.14.0. Add conditional support for os.version based on client node version.